### PR TITLE
Using API for creating included profiles

### DIFF
--- a/API.txt
+++ b/API.txt
@@ -965,7 +965,7 @@ output: ListOfEntries('result')
 output: Output('summary', type=[<type 'unicode'>, <type 'NoneType'>])
 output: Output('truncated', type=[<type 'bool'>])
 command: certprofile_import/1
-args: 1,8,3
+args: 1,9,3
 arg: Str('cn', cli_name='id')
 option: Flag('all', autofill=True, cli_name='all', default=False)
 option: Str('description', cli_name='desc')
@@ -973,6 +973,7 @@ option: Str('file', cli_name='file')
 option: DNParam('ipacertfieldmapping*')
 option: Bool('ipacertprofilestoreissued', cli_name='store', default=True)
 option: Str('mappings_file?', cli_name='mappings_file')
+option: Bool('overwrite?', default=False)
 option: Flag('raw', autofill=True, cli_name='raw', default=False)
 option: Str('version?')
 output: Entry('result')

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1170,6 +1170,7 @@ fi
 %{_usr}/share/ipa/advise/legacy/*.template
 %dir %{_usr}/share/ipa/profiles
 %{_usr}/share/ipa/profiles/*.cfg
+%{_usr}/share/ipa/profiles/*.mappings.json
 %dir %{_usr}/share/ipa/ffextension
 %{_usr}/share/ipa/ffextension/bootstrap.js
 %{_usr}/share/ipa/ffextension/install.rdf

--- a/install/share/profiles/Makefile.am
+++ b/install/share/profiles/Makefile.am
@@ -3,7 +3,9 @@ NULL =
 appdir = $(IPA_DATA_DIR)/profiles
 app_DATA =				\
 	caIPAserviceCert.cfg		\
+	caIPAserviceCert.mappings.json		\
 	caIPAuserCert.cfg		\
+	caIPAuserCert.mappings.json		\
 	IECUserRoles.cfg		\
 	$(NULL)
 

--- a/install/share/profiles/caIPAserviceCert.mappings.json
+++ b/install/share/profiles/caIPAserviceCert.mappings.json
@@ -1,0 +1,9 @@
+[
+    {
+        "syntax": "syntaxSubject",
+        "data": [
+            "dataHostCN"
+        ]
+    }
+]
+

--- a/install/share/profiles/caIPAuserCert.mappings.json
+++ b/install/share/profiles/caIPAuserCert.mappings.json
@@ -1,0 +1,14 @@
+[
+    {
+        "syntax": "syntaxSubject",
+        "data": [
+            "dataUsernameCN"
+        ]
+    },
+    {
+        "syntax": "syntaxSAN",
+        "data": [
+            "dataEmail"
+        ]
+    }
+]

--- a/ipapython/dogtag.py
+++ b/ipapython/dogtag.py
@@ -40,25 +40,15 @@ except ImportError:
 if six.PY3:
     unicode = str
 
-Profile = collections.namedtuple('Profile', ['profile_id', 'description', 'store_issued', 'field_mappings'])
+Profile = collections.namedtuple('Profile', ['profile_id', 'description', 'store_issued'])
 FieldMapping = collections.namedtuple('FieldMapping', ['id', 'syntax_mapping', 'data_mappings'])
 MappingRuleset = collections.namedtuple('MappingRuleset', ['id', 'description', 'transformations'])
 TransformationRule = collections.namedtuple('TransformationRule', ['id', 'template', 'helpers'])
 
 INCLUDED_PROFILES = (
-    Profile(u'caIPAserviceCert', u'Standard profile for network services', True,
-        [u'hostSubject', u'DNSSAN']),
-    Profile(u'caIPAuserCert', u'Standard profile for users', True,
-        [u'userSubject', u'emailSAN']),
-    Profile(u'IECUserRoles', u'User profile that includes IECUserRoles extension from request', True, []),
-)
-
-# TODO(blipton): Use the json file import method instead
-INCLUDED_FIELD_MAPPINGS = (
-    FieldMapping(u'hostSubject', u'syntaxSubject', [u'dataHostCN']),
-    FieldMapping(u'userSubject', u'syntaxSubject', [u'dataUsernameCN']),
-    FieldMapping(u'DNSSAN', u'syntaxSAN', [u'dataDNS']),
-    FieldMapping(u'emailSAN', u'syntaxSAN', [u'dataEmail']),
+    Profile(u'caIPAserviceCert', u'Standard profile for network services', True),
+    Profile(u'caIPAuserCert', u'Standard profile for users', True),
+    Profile(u'IECUserRoles', u'User profile that includes IECUserRoles extension from request', True),
 )
 
 INCLUDED_MAPPING_RULESETS = (

--- a/ipaserver/plugins/certmapping.py
+++ b/ipaserver/plugins/certmapping.py
@@ -457,6 +457,9 @@ class certmapping(Backend):
         return self.import_profile_mappings(profile_id, mappings)
 
     def import_profile_mappings(self, profile_id, mappings, mapping_names=None, old_mappings=None):
+        self.debug('Backend.certmapping.import_profile_mappings(profile_id=%s,'
+                'mappings=%s, mapping_names=%s, old_mappings=%s)' %
+                (profile_id, mappings, mapping_names, old_mappings))
         # Validate user input
         if not isinstance(mappings, list):
             raise errors.ValidationError(name=_('mappings_file'),

--- a/ipaserver/plugins/dogtag.py
+++ b/ipaserver/plugins/dogtag.py
@@ -2056,7 +2056,9 @@ class RestClient(Backend):
             method='GET'
         )
         cookies = ipapython.cookie.Cookie.parse(resp_headers.get('set-cookie', ''))
-        if status != 200 or len(cookies) == 0:
+        if status == 409:
+            raise errors.DuplicateEntry
+        elif status != 200 or len(cookies) == 0:
             raise errors.RemoteRetrieveError(reason=_('Failed to authenticate to CA REST API'))
         self.cookie = str(cookies[0])
         return self


### PR DESCRIPTION
This is an experiment in using the API to create the included mapping rules instead of creating them directly with LDAP. I think it's a good approach, but it turned out to touch a bunch of things so I'm leaving it as a separate branch for now.
